### PR TITLE
Fix auth repo method name

### DIFF
--- a/auth/src/main/java/org/newshabit/app/auth/application/port/output/AuthRepositoryOutputPort.java
+++ b/auth/src/main/java/org/newshabit/app/auth/application/port/output/AuthRepositoryOutputPort.java
@@ -5,5 +5,5 @@ import org.newshabit.app.auth.infrastructure.adapter.outbound.persistence.entity
 
 public interface AuthRepositoryOutputPort {
 	void save(AuthEntity entity);
-	Optional<AuthEntity> findBySocialIdAndDeviceId(int userId, String deviceId);
+    Optional<AuthEntity> findByUserIdAndDeviceId(int userId, String deviceId);
 }

--- a/auth/src/main/java/org/newshabit/app/auth/application/service/TokenProviderService.java
+++ b/auth/src/main/java/org/newshabit/app/auth/application/service/TokenProviderService.java
@@ -29,7 +29,7 @@ public class TokenProviderService implements TokenProviderUseCase {
 		String accessToken = tokenProviderOutputPort.createAccessToken(socialId, userId, deviceId, roles);
 		String refreshToken = tokenProviderOutputPort.createRefreshToken(socialId, userId, deviceId, roles);
 
-		Optional<AuthEntity> authEntityOptional = authRepositoryOutputPort.findBySocialIdAndDeviceId(userId, deviceId);
+                Optional<AuthEntity> authEntityOptional = authRepositoryOutputPort.findByUserIdAndDeviceId(userId, deviceId);
 
 		AuthEntity authEntity;
 

--- a/auth/src/main/java/org/newshabit/app/auth/infrastructure/adapter/outbound/persistence/AuthRepositoryAdapter.java
+++ b/auth/src/main/java/org/newshabit/app/auth/infrastructure/adapter/outbound/persistence/AuthRepositoryAdapter.java
@@ -12,9 +12,9 @@ import org.springframework.stereotype.Component;
 public class AuthRepositoryAdapter implements AuthRepositoryOutputPort {
 	private final AuthRepository authRepository;
 
-	public Optional<AuthEntity> findBySocialIdAndDeviceId(int userId, String deviceId) {
-		return authRepository.findAuthEntityByUserIdAndDeviceId(userId, deviceId);
-	}
+    public Optional<AuthEntity> findByUserIdAndDeviceId(int userId, String deviceId) {
+            return authRepository.findAuthEntityByUserIdAndDeviceId(userId, deviceId);
+        }
 
 	public void save(AuthEntity entity) {
 		authRepository.save(entity);


### PR DESCRIPTION
## Summary
- rename `findBySocialIdAndDeviceId` to `findByUserIdAndDeviceId`
- update adapter and service accordingly

## Testing
- `gradle test` *(fails: Plugin not found)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684981524e5c832b8f160b6eb544a7cb