### PR TITLE
Fix randomSleep range handling

### DIFF
--- a/common/src/main/java/org/newshabit/app/common/util/SleepUtil.java
+++ b/common/src/main/java/org/newshabit/app/common/util/SleepUtil.java
@@ -5,15 +5,19 @@ import java.util.Random;
 public class SleepUtil {
 	private static final Random random = new Random();
 	private static final int DEFAULT_START_TIME = 1000;
-	private static final int DEFAULT_END_TIME = 2000;
-	public static void randomSleep(int startTime, int endTime) {
-		try {
-			int sleepTime = startTime + random.nextInt(endTime);
-			Thread.sleep(sleepTime);
-		} catch (InterruptedException e) {
-			Thread.currentThread().interrupt();
-			throw new RuntimeException("Sleep interrupted", e);
-		}
+        private static final int DEFAULT_END_TIME = 2000;
+        public static void randomSleep(int startTime, int endTime) {
+                if (endTime < startTime) {
+                        throw new IllegalArgumentException("endTime must be greater than or equal to startTime");
+                }
+
+                try {
+                        int sleepTime = startTime + random.nextInt(endTime - startTime + 1);
+                        Thread.sleep(sleepTime);
+                } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException("Sleep interrupted", e);
+                }
 	}
 
 	public static void randomSleep() {


### PR DESCRIPTION
## Summary
- ensure SleepUtil.sleep range respects start and end boundaries and add validation

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68497f8866d8832b908c6aaf0377ad13