### PR TITLE
Add cascading deletions for account removal

### DIFF
--- a/auth/src/main/java/org/newshabit/app/auth/application/port/output/AuthRepositoryOutputPort.java
+++ b/auth/src/main/java/org/newshabit/app/auth/application/port/output/AuthRepositoryOutputPort.java
@@ -4,6 +4,12 @@ import java.util.Optional;
 import org.newshabit.app.auth.infrastructure.adapter.outbound.persistence.entity.AuthEntity;
 
 public interface AuthRepositoryOutputPort {
-	void save(AuthEntity entity);
+        void save(AuthEntity entity);
     Optional<AuthEntity> findByUserIdAndDeviceId(int userId, String deviceId);
+
+    /**
+     * 주어진 사용자 ID에 해당하는 인증 데이터를 모두 삭제합니다.
+     * @param userId 삭제할 사용자 ID
+     */
+    void deleteByUserId(int userId);
 }

--- a/auth/src/main/java/org/newshabit/app/auth/infrastructure/adapter/outbound/persistence/AuthRepositoryAdapter.java
+++ b/auth/src/main/java/org/newshabit/app/auth/infrastructure/adapter/outbound/persistence/AuthRepositoryAdapter.java
@@ -10,13 +10,18 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class AuthRepositoryAdapter implements AuthRepositoryOutputPort {
-	private final AuthRepository authRepository;
+        private final AuthRepository authRepository;
 
     public Optional<AuthEntity> findByUserIdAndDeviceId(int userId, String deviceId) {
             return authRepository.findAuthEntityByUserIdAndDeviceId(userId, deviceId);
         }
 
-	public void save(AuthEntity entity) {
-		authRepository.save(entity);
-	}
+        public void save(AuthEntity entity) {
+                authRepository.save(entity);
+        }
+
+        @Override
+        public void deleteByUserId(int userId) {
+                authRepository.deleteByUserId(userId);
+        }
 }

--- a/auth/src/main/java/org/newshabit/app/auth/infrastructure/adapter/outbound/persistence/repository/AuthRepository.java
+++ b/auth/src/main/java/org/newshabit/app/auth/infrastructure/adapter/outbound/persistence/repository/AuthRepository.java
@@ -8,5 +8,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AuthRepository extends JpaRepository<AuthEntity, Integer> {
 
-	Optional<AuthEntity> findAuthEntityByUserIdAndDeviceId(int userId, String deviceId);
+        Optional<AuthEntity> findAuthEntityByUserIdAndDeviceId(int userId, String deviceId);
+
+        void deleteByUserId(int userId);
 }

--- a/user/src/main/java/org/newshabit/app/user/application/port/input/MemberUserCase.java
+++ b/user/src/main/java/org/newshabit/app/user/application/port/input/MemberUserCase.java
@@ -10,4 +10,10 @@ public interface MemberUserCase {
 	void updateUsername(int userId, String username) throws NotFoundException;
 	void updateInterestCategories(int userId, List<NewsCategory> interestCategories) throws NotFoundException;
 	void updateDailyGoal(int userId, int dailyGoal) throws NotFoundException;
+
+	/**
+	 * 사용자 계정을 삭제합니다.
+	 * @param userId 삭제할 사용자의 아이디
+	 */
+	void deleteMember(int userId);
 }

--- a/user/src/main/java/org/newshabit/app/user/application/port/output/UserDailyGoalOutputPort.java
+++ b/user/src/main/java/org/newshabit/app/user/application/port/output/UserDailyGoalOutputPort.java
@@ -3,6 +3,12 @@ package org.newshabit.app.user.application.port.output;
 import org.newshabit.app.user.domain.model.UserDailyGoal;
 
 public interface UserDailyGoalOutputPort {
-	UserDailyGoal save(UserDailyGoal userDailyGoal);
-	UserDailyGoal findLatestByUserId(int userId);
+        UserDailyGoal save(UserDailyGoal userDailyGoal);
+        UserDailyGoal findLatestByUserId(int userId);
+
+        /**
+         * 사용자와 연결된 일일 목표 기록을 삭제합니다.
+         * @param userId 사용자 ID
+         */
+        void deleteByUserId(int userId);
 }

--- a/user/src/main/java/org/newshabit/app/user/application/port/output/UserRepositoryOutputPort.java
+++ b/user/src/main/java/org/newshabit/app/user/application/port/output/UserRepositoryOutputPort.java
@@ -11,4 +11,11 @@ public interface UserRepositoryOutputPort {
 	Optional<User> findByUserId(int id);
 	void updateUsername(User user, String username);
 	void updateInterestCategories(User user, List<NewsCategory> interestCategories);
+
+	/**
+	* 사용자 엔티티를 삭제합니다.
+	* 연관된 데이터는 DB 제약조건에 따라 함께 삭제됩니다.
+	* @param userId 삭제할 사용자 ID
+	*/
+	void deleteById(int userId);
 }

--- a/user/src/main/java/org/newshabit/app/user/application/service/MemberService.java
+++ b/user/src/main/java/org/newshabit/app/user/application/service/MemberService.java
@@ -7,6 +7,7 @@ import org.newshabit.app.common.domain.enums.NewsCategory;
 import org.newshabit.app.user.application.port.input.MemberUserCase;
 import org.newshabit.app.user.application.port.output.UserDailyGoalOutputPort;
 import org.newshabit.app.user.application.port.output.UserRepositoryOutputPort;
+import org.newshabit.app.auth.application.port.output.AuthRepositoryOutputPort;
 import org.newshabit.app.user.common.exception.DuplicatedException;
 import org.newshabit.app.user.common.exception.ErrorCode;
 import org.newshabit.app.user.domain.model.MemberSettings;
@@ -18,8 +19,9 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class MemberService implements MemberUserCase {
-	private final UserRepositoryOutputPort userRepositoryOutputPort;
-	private final UserDailyGoalOutputPort userDailyGoalOutputPort;
+        private final UserRepositoryOutputPort userRepositoryOutputPort;
+        private final UserDailyGoalOutputPort userDailyGoalOutputPort;
+        private final AuthRepositoryOutputPort authRepositoryOutputPort;
 
 	private final int DAILY_GOAL_UPDATE_ALLOWED_DAYS = 7;
 
@@ -75,4 +77,11 @@ public class MemberService implements MemberUserCase {
 		userDailyGoalOutputPort.save(latestDailyGoal);
 		userDailyGoalOutputPort.save(newDailyGoal);
 	}
+	@Override
+        public void deleteMember(int userId) {
+                authRepositoryOutputPort.deleteByUserId(userId);
+                userDailyGoalOutputPort.deleteByUserId(userId);
+
+                userRepositoryOutputPort.deleteById(userId);
+        }
 }

--- a/user/src/main/java/org/newshabit/app/user/infrastructure/adapter/inbound/web/UserController.java
+++ b/user/src/main/java/org/newshabit/app/user/infrastructure/adapter/inbound/web/UserController.java
@@ -23,6 +23,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -84,6 +85,13 @@ public class UserController {
 		@Valid @RequestBody DailyGoalRequest dailyGoalRequest) throws NotFoundException {
 
 		memberUserCase.updateDailyGoal(userDetail.getUserId(), dailyGoalRequest.dailyGoal());
+
+		return ResponseEntity.ok(CommonResponse.success());
+	}
+
+	@DeleteMapping("/v2/member")
+	public ResponseEntity<CommonResponse<Object>> deleteMember(@AuthenticationPrincipal CustomUserDetail userDetail) {
+		memberUserCase.deleteMember(userDetail.getUserId());
 
 		return ResponseEntity.ok(CommonResponse.success());
 	}

--- a/user/src/main/java/org/newshabit/app/user/infrastructure/adapter/outbound/persistence/UserDailyGoalRepositoryAdapter.java
+++ b/user/src/main/java/org/newshabit/app/user/infrastructure/adapter/outbound/persistence/UserDailyGoalRepositoryAdapter.java
@@ -32,13 +32,18 @@ public class UserDailyGoalRepositoryAdapter implements UserDailyGoalOutputPort {
 	}
 
 	@Override
-	public UserDailyGoal findLatestByUserId(int userId) throws NotFoundException {
-		Optional<UserDailyGoalEntity> optionalEntity = userDailyGoalRepository.findLatestByUserId(userId);
+        public UserDailyGoal findLatestByUserId(int userId) throws NotFoundException {
+                Optional<UserDailyGoalEntity> optionalEntity = userDailyGoalRepository.findLatestByUserId(userId);
 
 		if (optionalEntity.isEmpty()) {
 			throw new NotFoundException();
 		}
 
-		return entityMapper.toDomain(optionalEntity.get());
-	}
+                return entityMapper.toDomain(optionalEntity.get());
+        }
+
+        @Override
+        public void deleteByUserId(int userId) {
+                userDailyGoalRepository.deleteAllByUserId(userId);
+        }
 }

--- a/user/src/main/java/org/newshabit/app/user/infrastructure/adapter/outbound/persistence/UserRepositoryAdapter.java
+++ b/user/src/main/java/org/newshabit/app/user/infrastructure/adapter/outbound/persistence/UserRepositoryAdapter.java
@@ -59,4 +59,8 @@ public class UserRepositoryAdapter implements UserRepositoryOutputPort {
 
 		userRepository.save(userEntity);
 	}
+	@Override
+	public void deleteById(int userId) {
+		userRepository.deleteById(userId);
+	}
 }

--- a/user/src/main/java/org/newshabit/app/user/infrastructure/adapter/outbound/persistence/repository/UserDailyGoalRepository.java
+++ b/user/src/main/java/org/newshabit/app/user/infrastructure/adapter/outbound/persistence/repository/UserDailyGoalRepository.java
@@ -21,10 +21,12 @@ public interface UserDailyGoalRepository extends JpaRepository<UserDailyGoalEnti
 	List<UserDailyGoalEntity> findByUserId(@Param("userId") Integer userId, Pageable pageable);
 
 
-	default Optional<UserDailyGoalEntity> findLatestByUserId(@Param("userId") Integer userId) {
-		List<UserDailyGoalEntity> list =
-			findByUserId(userId, PageRequest.of(0, 1));
-		return list.stream().findFirst();
-	}
+        default Optional<UserDailyGoalEntity> findLatestByUserId(@Param("userId") Integer userId) {
+                List<UserDailyGoalEntity> list =
+                        findByUserId(userId, PageRequest.of(0, 1));
+                return list.stream().findFirst();
+        }
+
+        void deleteAllByUserId(Integer userId);
 
 }


### PR DESCRIPTION
## Summary
- cascade member removal to auth and goal logs
- provide repository methods to delete auth records and daily goals by user ID
- invoke these deletions in MemberService

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_684e95297f1c832ba808cd5bbb15bd11